### PR TITLE
fixed null-query-param error for fetchs bug

### DIFF
--- a/frontend/administrador/agregarUsuario/index.html
+++ b/frontend/administrador/agregarUsuario/index.html
@@ -60,8 +60,8 @@
     <script>
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/administrador`)

--- a/frontend/administrador/editarUsuario/index.html
+++ b/frontend/administrador/editarUsuario/index.html
@@ -61,12 +61,12 @@
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         let id_usuario_a_editar = new URLSearchParams(window.location.search).get("id")
 
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
-        if (id_usuario_a_editar == null) {
-            id_usuario_a_editar = -2147483648
+        if (id_usuario_a_editar == "") {
+            id_usuario_a_editar = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/administrador`)

--- a/frontend/administrador/index.html
+++ b/frontend/administrador/index.html
@@ -51,8 +51,8 @@
     <script>
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/administrador`)

--- a/frontend/administrador/informacionUsuario/index.html
+++ b/frontend/administrador/informacionUsuario/index.html
@@ -66,12 +66,12 @@
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         let id_usuario_info = new URLSearchParams(window.location.search).get("id")
 
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
-        if (id_usuario_info == null) {
-            id_usuario_info = -2147483648
+        if (id_usuario_info == "") {
+            sessionID = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/administrador`)

--- a/frontend/cliente/index.html
+++ b/frontend/cliente/index.html
@@ -50,8 +50,8 @@
     <script>
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/cliente`)

--- a/frontend/cliente/informacionEquipo/index.html
+++ b/frontend/cliente/informacionEquipo/index.html
@@ -76,12 +76,12 @@
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         let id_equipo_info = new URLSearchParams(window.location.search).get("id")
 
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
-        if (id_equipo_info == null) {
-            id_equipo_info = -2147483648
+        if (id_equipo_info == "") {
+            id_equipo_info = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/cliente`)

--- a/frontend/tecnico/agregarCliente/index.html
+++ b/frontend/tecnico/agregarCliente/index.html
@@ -50,8 +50,8 @@
     <script>
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/tecnico`)

--- a/frontend/tecnico/agregarEquipo/index.html
+++ b/frontend/tecnico/agregarEquipo/index.html
@@ -69,8 +69,8 @@
     <script>
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
 
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/tecnico`)

--- a/frontend/tecnico/editarCliente/index.html
+++ b/frontend/tecnico/editarCliente/index.html
@@ -52,12 +52,12 @@
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         let id_cliente_a_editar = new URLSearchParams(window.location.search).get("id")
 
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
-        if (id_cliente_a_editar == null) {
-            id_cliente_a_editar = -2147483648
+        if (id_cliente_a_editar == "") {
+            id_cliente_a_editar = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/tecnico`)

--- a/frontend/tecnico/editarEquipo/index.html
+++ b/frontend/tecnico/editarEquipo/index.html
@@ -81,12 +81,12 @@
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         let id_equipo_a_editar = new URLSearchParams(window.location.search).get("id")
 
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
 
-        if (id_equipo_a_editar == null) {
-            id_equipo_a_editar = -2147483648
+        if (id_equipo_a_editar == "") {
+            id_equipo_a_editar = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/tecnico`)

--- a/frontend/tecnico/index.html
+++ b/frontend/tecnico/index.html
@@ -21,9 +21,9 @@
     <h2 id="bienvenida">BIENVENIDO/A:</h2> <!-- Esto se actualiza después en la función show_data() -->
 
     <div class="tab-info">
-        <h3>Haz click en el tipo del equipo o en el cliente para ver la respectiva información...</h3>
+        <h3>Haz click en un equipo para ver su información...</h3>
         <div class="tab-btns">  
-            <button class="btn btn-warning btn-add" onclick=goToListClients()>Ver la lista de los clientes</button>     
+            <button class="btn btn-warning btn-add" onclick=goToClientsList()>Ver la lista de clientes</button>     
             <button class="btn btn-primary btn-add" id="addClient" onclick=goToAddClient()>Registrar un nuevo cliente</button>
             <button class="btn btn-info btn-add" id="addClient" onclick=goToAddDevice()>Registrar un nuevo equipo</button>
         </div>
@@ -57,8 +57,8 @@
     <script>
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
         
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/tecnico`)
@@ -87,6 +87,12 @@
 
             for (let i = 0; i < equiposData.length; i++) {
                 equipo = document.createElement("tr")
+                equipo.setAttribute("style", "cursor: pointer")
+                equipo.onclick = function() {
+                    fetch(`http://127.0.0.1:5000/set_InfoID/${equiposData[i]["id"]}/equipo`)
+                    .catch((error) => console.log(`ERROR: ${error}`))
+                    window.location.href = `http://localhost:8000/tecnico/informacionEquipo?id=${equiposData[i]["id"]}&sessionID=${sessionID}`
+                }
                 
                 if (equiposData[i]["estado"] == "En revisión/reparación") {
                     equipo.setAttribute("class", "revision")
@@ -103,12 +109,6 @@
 
                 columnDEVICETYPE = document.createElement("td")
                 columnDEVICETYPE.innerText = equiposData[i]["tipo_equipo"]
-                columnDEVICETYPE.setAttribute("class", "hrefs")
-                columnDEVICETYPE.onclick = function() {
-                    fetch(`http://127.0.0.1:5000/set_InfoID/${equiposData[i]["id"]}/equipo`)
-                    .catch((error) => console.log(`ERROR: ${error}`))
-                    window.location.href = `http://localhost:8000/tecnico/informacionEquipo?id=${equiposData[i]["id"]}&sessionID=${sessionID}`
-                }
                 equipo.append(columnDEVICETYPE)
                 
                 columnBRAND = document.createElement("td")
@@ -144,7 +144,7 @@
             window.location.href = `http://localhost:8000/tecnico/agregarEquipo?sessionID=${sessionID}`
         }
 
-        function goToListClients() {
+        function goToClientsList() {
             window.location.href = `http://localhost:8000/tecnico/listaClientes?sessionID=${sessionID}`
         }
 

--- a/frontend/tecnico/informacionEquipo/index.html
+++ b/frontend/tecnico/informacionEquipo/index.html
@@ -85,12 +85,12 @@
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         let id_equipo_info = new URLSearchParams(window.location.search).get("id")
 
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
-
-        if (id_equipo_info == null) {
-            id_equipo_info = -2147483648
+        
+        if (id_equipo_info == "") {
+            id_equipo_info = "null"
         }
 
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/tecnico`)

--- a/frontend/tecnico/listaClientes/index.html
+++ b/frontend/tecnico/listaClientes/index.html
@@ -54,8 +54,8 @@
     <script>
         let sessionID = new URLSearchParams(window.location.search).get("sessionID")
         
-        if (sessionID == null) {
-            sessionID = -2147483648
+        if (sessionID == "") {
+            sessionID = "null"
         }
         
         fetch(`http://127.0.0.1:5000/verify_session/${sessionID}/tecnico`)


### PR DESCRIPTION
**FIXED**
Cuando se editaban las query-params y no se le ponia nada, osea, valían "", el fetch que utilizaba esos valores tiraba error, porque el backend no es capaz de distinguirlo y no se pasa como valor "None". Por eso hice que cuando aparezca el valor "", lo cambie a un string con al menos 1 caracter para que el backend sepa lo que tenga que hacer.
Antes se ponía con el número -2147483648, pero termino siendo una mejor idea cambiarlo al string "null", como referencia a que no se puso nada.